### PR TITLE
 Add per-chain TVL breakdown and refine interpolation/extrapolation behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ avg_tvls.py_old
 .coverage
 htmlcov/
 .pytest_cache/
+
+# Ruff cache
+.ruff_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint lint-fix format format-check test cichecks help
+.PHONY: lint lint-fix format format-check test cichecks tvl avgtvl help
 
 help:
 	@echo "Available commands:"
@@ -8,6 +8,19 @@ help:
 	@echo "  make format-check - Check formatting without changing files"
 	@echo "  make test         - Run tests"
 	@echo "  make cichecks     - Run all CI checks (test, lint, format-check)"
+	@echo "  make tvl          - Get TVL data (use: make tvl PROTOCOL=euler START=2025-01-01 END=2025-01-15)"
+	@echo "  make avgtvl       - Get average TVL (use: make avgtvl PROTOCOL=euler START=2025-01-01 END=2025-01-15)"
+	@echo ""
+	@echo "TVL Examples:"
+	@echo "  make tvl PROTOCOL=euler START=2025-01-01 END=2025-01-15"
+	@echo "  make tvl PROTOCOL=aave START=2025-01-01 END=2025-01-31"
+	@echo "  make tvl PROTOCOL=uniswap START=2024-12-01 END=2024-12-31 OPTS='--no-extrapolate'"
+	@echo "  make tvl PROTOCOL=euler START=2025-01-01 END=2025-01-15 OPTS='--mean'"
+	@echo ""
+	@echo "Average TVL Examples:"
+	@echo "  make avgtvl PROTOCOL=euler START=2025-01-01 END=2025-01-15"
+	@echo "  make avgtvl PROTOCOL=aave START=2025-01-01 END=2025-01-31"
+	@echo "  make avgtvl PROTOCOL=compound START=2024-01-01 END=2024-12-31"
 
 lint:
 	uv run ruff check .
@@ -63,3 +76,28 @@ cichecks:
 		exit 1; \
 	fi
 
+# Get TVL data for a protocol
+# Usage: make tvl PROTOCOL=euler START=2025-01-01 END=2025-01-15
+# Optional: OPTS='--no-extrapolate' or OPTS='--mean'
+tvl:
+	@if [ -z "$(PROTOCOL)" ] || [ -z "$(START)" ] || [ -z "$(END)" ]; then \
+		echo "Error: Missing required parameters"; \
+		echo "Usage: make tvl PROTOCOL=<protocol> START=<start-date> END=<end-date>"; \
+		echo "Example: make tvl PROTOCOL=euler START=2025-01-01 END=2025-01-15"; \
+		echo "Optional: Add OPTS='--mean' or OPTS='--no-extrapolate'"; \
+		exit 1; \
+	fi
+	@uv run python avg_tvls.py $(PROTOCOL) $(START) $(END) $(OPTS)
+
+# Get average TVL for a protocol (with interpolation/extrapolation)
+# Usage: make avgtvl PROTOCOL=euler START=2025-01-01 END=2025-01-15
+# Optional: OPTS='--no-extrapolate' to disable extrapolation
+avgtvl:
+	@if [ -z "$(PROTOCOL)" ] || [ -z "$(START)" ] || [ -z "$(END)" ]; then \
+		echo "Error: Missing required parameters"; \
+		echo "Usage: make avgtvl PROTOCOL=<protocol> START=<start-date> END=<end-date>"; \
+		echo "Example: make avgtvl PROTOCOL=euler START=2025-01-01 END=2025-01-15"; \
+		echo "Optional: Add OPTS='--no-extrapolate' to disable extrapolation"; \
+		exit 1; \
+	fi
+	@uv run python avg_tvls.py $(PROTOCOL) $(START) $(END) --mean $(OPTS)

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ help:
 	@echo "  make tvl PROTOCOL=aave START=2025-01-01 END=2025-01-31"
 	@echo "  make tvl PROTOCOL=uniswap START=2024-12-01 END=2024-12-31 OPTS='--extrapolate'"
 	@echo "  make tvl PROTOCOL=euler START=2025-01-01 END=2025-01-15 OPTS='--mean'"
+	@echo "  make tvl PROTOCOL=aave START=2025-01-01 END=2025-01-15 OPTS='--no-by-chain'"
 	@echo ""
 	@echo "Average TVL Examples:"
 	@echo "  make avgtvl PROTOCOL=euler START=2025-01-01 END=2025-01-15"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help:
 	@echo "TVL Examples:"
 	@echo "  make tvl PROTOCOL=euler START=2025-01-01 END=2025-01-15"
 	@echo "  make tvl PROTOCOL=aave START=2025-01-01 END=2025-01-31"
-	@echo "  make tvl PROTOCOL=uniswap START=2024-12-01 END=2024-12-31 OPTS='--no-extrapolate'"
+	@echo "  make tvl PROTOCOL=uniswap START=2024-12-01 END=2024-12-31 OPTS='--extrapolate'"
 	@echo "  make tvl PROTOCOL=euler START=2025-01-01 END=2025-01-15 OPTS='--mean'"
 	@echo ""
 	@echo "Average TVL Examples:"
@@ -78,26 +78,26 @@ cichecks:
 
 # Get TVL data for a protocol
 # Usage: make tvl PROTOCOL=euler START=2025-01-01 END=2025-01-15
-# Optional: OPTS='--no-extrapolate' or OPTS='--mean'
+# Optional: OPTS='--extrapolate' or OPTS='--mean'
 tvl:
 	@if [ -z "$(PROTOCOL)" ] || [ -z "$(START)" ] || [ -z "$(END)" ]; then \
 		echo "Error: Missing required parameters"; \
 		echo "Usage: make tvl PROTOCOL=<protocol> START=<start-date> END=<end-date>"; \
 		echo "Example: make tvl PROTOCOL=euler START=2025-01-01 END=2025-01-15"; \
-		echo "Optional: Add OPTS='--mean' or OPTS='--no-extrapolate'"; \
+		echo "Optional: Add OPTS='--mean' or OPTS='--extrapolate'"; \
 		exit 1; \
 	fi
 	@uv run python avg_tvls.py $(PROTOCOL) $(START) $(END) $(OPTS)
 
-# Get average TVL for a protocol (with interpolation/extrapolation)
+# Get average TVL for a protocol (with interpolation)
 # Usage: make avgtvl PROTOCOL=euler START=2025-01-01 END=2025-01-15
-# Optional: OPTS='--no-extrapolate' to disable extrapolation
+# Optional: OPTS='--extrapolate' to enable extrapolation at edges
 avgtvl:
 	@if [ -z "$(PROTOCOL)" ] || [ -z "$(START)" ] || [ -z "$(END)" ]; then \
 		echo "Error: Missing required parameters"; \
 		echo "Usage: make avgtvl PROTOCOL=<protocol> START=<start-date> END=<end-date>"; \
 		echo "Example: make avgtvl PROTOCOL=euler START=2025-01-01 END=2025-01-15"; \
-		echo "Optional: Add OPTS='--no-extrapolate' to disable extrapolation"; \
+		echo "Optional: Add OPTS='--extrapolate' to enable extrapolation"; \
 		exit 1; \
 	fi
 	@uv run python avg_tvls.py $(PROTOCOL) $(START) $(END) --mean $(OPTS)

--- a/test_avg_tvls.py
+++ b/test_avg_tvls.py
@@ -8,7 +8,15 @@ from unittest import mock
 # Add parent directory to path to import avg_tvls
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from avg_tvls import _find_nearest_dates, get_average_tvl, get_tvl_dataset
+from avg_tvls import _find_nearest_dates, _get_extrapolation_slope, get_average_tvl, get_tvl_dataset
+
+
+def make_tvl_entry(date: datetime.date, tvl_usd: float) -> dict:
+    """Helper to create a TVL data entry with Unix timestamp"""
+    timestamp = int(
+        datetime.datetime.combine(date, datetime.time.min, tzinfo=datetime.timezone.utc).timestamp()
+    )
+    return {"date": timestamp, "totalLiquidityUSD": tvl_usd}
 
 
 class TestTVLDataset(unittest.TestCase):
@@ -32,24 +40,15 @@ class TestTVLDataset(unittest.TestCase):
     def test_raw_data_only(self):
         """Test when all dates have raw data (no interpolation needed)"""
         # Create TVL data for 3 consecutive days
-        base_date = datetime.date(2024, 1, 1)
+        base_date = datetime.date(2025, 1, 1)
         tvl_data = [
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date + datetime.timedelta(days=i),
-                        datetime.time.min,
-                        tzinfo=datetime.timezone.utc,
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1000000.0 + (i * 100000),
-            }
+            make_tvl_entry(base_date + datetime.timedelta(days=i), 1000000.0 + (i * 100000))
             for i in range(3)
         ]
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-03")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03")
 
         self.assertEqual(len(result), 3)
         self.assertFalse(any(row["is_interpolated"] for row in result))
@@ -60,31 +59,15 @@ class TestTVLDataset(unittest.TestCase):
     def test_linear_interpolation_between_points(self):
         """Test linear interpolation between two data points"""
         # Data on Jan 1 and Jan 3, missing Jan 2
-        base_date = datetime.date(2024, 1, 1)
+        base_date = datetime.date(2025, 1, 1)
         tvl_data = [
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date, datetime.time.min, tzinfo=datetime.timezone.utc
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1000000.0,
-            },
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date + datetime.timedelta(days=2),
-                        datetime.time.min,
-                        tzinfo=datetime.timezone.utc,
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1200000.0,
-            },
+            make_tvl_entry(base_date, 1000000.0),
+            make_tvl_entry(base_date + datetime.timedelta(days=2), 1200000.0),
         ]
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-03")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03")
 
         self.assertEqual(len(result), 3)
         # Jan 1: raw data
@@ -98,26 +81,18 @@ class TestTVLDataset(unittest.TestCase):
         self.assertEqual(result[2]["tvl"], 1200000.0)
 
     def test_forward_fill_at_start(self):
-        """Test forward-fill when data is missing at the start of range"""
+        """Test forward-fill when data is missing at the start of range (only one data point)"""
         # Data starts on Jan 2, but range starts on Jan 1
-        base_date = datetime.date(2024, 1, 2)
-        tvl_data = [
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date, datetime.time.min, tzinfo=datetime.timezone.utc
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1000000.0,
-            }
-        ]
+        # With only one data point, should fallback to simple forward-fill
+        base_date = datetime.date(2025, 1, 2)
+        tvl_data = [make_tvl_entry(base_date, 1000000.0)]
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-02")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-02")
 
         self.assertEqual(len(result), 2)
-        # Jan 1: forward-fill from Jan 2
+        # Jan 1: forward-fill from Jan 2 (fallback with only 1 data point)
         self.assertTrue(result[0]["is_interpolated"])
         self.assertEqual(result[0]["tvl"], 1000000.0)
         # Jan 2: raw data
@@ -125,70 +100,37 @@ class TestTVLDataset(unittest.TestCase):
         self.assertEqual(result[1]["tvl"], 1000000.0)
 
     def test_backward_fill_at_end(self):
-        """Test backward-fill when data is missing at the end of range"""
+        """Test backward-fill when data is missing at the end of range (only one data point)"""
         # Data ends on Jan 1, but range ends on Jan 2
-        base_date = datetime.date(2024, 1, 1)
-        tvl_data = [
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date, datetime.time.min, tzinfo=datetime.timezone.utc
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1000000.0,
-            }
-        ]
+        # With only one data point, should fallback to simple backward-fill
+        base_date = datetime.date(2025, 1, 1)
+        tvl_data = [make_tvl_entry(base_date, 1000000.0)]
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-02")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-02")
 
         self.assertEqual(len(result), 2)
         # Jan 1: raw data
         self.assertFalse(result[0]["is_interpolated"])
         self.assertEqual(result[0]["tvl"], 1000000.0)
-        # Jan 2: backward-fill from Jan 1
+        # Jan 2: backward-fill from Jan 1 (fallback with only 1 data point)
         self.assertTrue(result[1]["is_interpolated"])
         self.assertEqual(result[1]["tvl"], 1000000.0)
 
     def test_complex_interpolation_scenario(self):
         """Test a complex scenario with multiple gaps"""
         # Data on Jan 1, Jan 4, Jan 6; missing Jan 2, 3, 5
-        base_date = datetime.date(2024, 1, 1)
+        base_date = datetime.date(2025, 1, 1)
         tvl_data = [
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date, datetime.time.min, tzinfo=datetime.timezone.utc
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1000000.0,
-            },
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date + datetime.timedelta(days=3),
-                        datetime.time.min,
-                        tzinfo=datetime.timezone.utc,
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1300000.0,
-            },
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date + datetime.timedelta(days=5),
-                        datetime.time.min,
-                        tzinfo=datetime.timezone.utc,
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1500000.0,
-            },
+            make_tvl_entry(base_date, 1000000.0),
+            make_tvl_entry(base_date + datetime.timedelta(days=3), 1300000.0),
+            make_tvl_entry(base_date + datetime.timedelta(days=5), 1500000.0),
         ]
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-06")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-06")
 
         self.assertEqual(len(result), 6)
         # Jan 1: raw
@@ -210,22 +152,13 @@ class TestTVLDataset(unittest.TestCase):
     def test_no_data_in_range_error(self):
         """Test error when no data exists in the specified range"""
         # Data exists but outside the range
-        base_date = datetime.date(2024, 2, 1)
-        tvl_data = [
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date, datetime.time.min, tzinfo=datetime.timezone.utc
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1000000.0,
-            }
-        ]
+        base_date = datetime.date(2025, 2, 1)
+        tvl_data = [make_tvl_entry(base_date, 1000000.0)]
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
         with self.assertRaises(ValueError) as context:
-            get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-31")
+            get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-31")
 
         self.assertIn("No TVL data available", str(context.exception))
 
@@ -258,61 +191,61 @@ class TestFindNearestDates(unittest.TestCase):
 
     def test_find_both_dates(self):
         """Test finding both previous and next dates"""
-        target = datetime.date(2024, 1, 3)
+        target = datetime.date(2025, 1, 3)
         available = [
-            datetime.date(2024, 1, 1),
-            datetime.date(2024, 1, 2),
-            datetime.date(2024, 1, 4),
-            datetime.date(2024, 1, 5),
+            datetime.date(2025, 1, 1),
+            datetime.date(2025, 1, 2),
+            datetime.date(2025, 1, 4),
+            datetime.date(2025, 1, 5),
         ]
 
         prev, next_date = _find_nearest_dates(target, available)
 
-        self.assertEqual(prev, datetime.date(2024, 1, 2))
-        self.assertEqual(next_date, datetime.date(2024, 1, 4))
+        self.assertEqual(prev, datetime.date(2025, 1, 2))
+        self.assertEqual(next_date, datetime.date(2025, 1, 4))
 
     def test_find_only_previous(self):
         """Test when only previous date exists"""
-        target = datetime.date(2024, 1, 5)
+        target = datetime.date(2025, 1, 5)
         available = [
-            datetime.date(2024, 1, 1),
-            datetime.date(2024, 1, 2),
-            datetime.date(2024, 1, 3),
+            datetime.date(2025, 1, 1),
+            datetime.date(2025, 1, 2),
+            datetime.date(2025, 1, 3),
         ]
 
         prev, next_date = _find_nearest_dates(target, available)
 
-        self.assertEqual(prev, datetime.date(2024, 1, 3))
+        self.assertEqual(prev, datetime.date(2025, 1, 3))
         self.assertIsNone(next_date)
 
     def test_find_only_next(self):
         """Test when only next date exists"""
-        target = datetime.date(2024, 1, 1)
+        target = datetime.date(2025, 1, 1)
         available = [
-            datetime.date(2024, 1, 3),
-            datetime.date(2024, 1, 4),
-            datetime.date(2024, 1, 5),
+            datetime.date(2025, 1, 3),
+            datetime.date(2025, 1, 4),
+            datetime.date(2025, 1, 5),
         ]
 
         prev, next_date = _find_nearest_dates(target, available)
 
         self.assertIsNone(prev)
-        self.assertEqual(next_date, datetime.date(2024, 1, 3))
+        self.assertEqual(next_date, datetime.date(2025, 1, 3))
 
     def test_target_equals_available_date(self):
         """Test when target equals an available date"""
-        target = datetime.date(2024, 1, 2)
+        target = datetime.date(2025, 1, 2)
         available = [
-            datetime.date(2024, 1, 1),
-            datetime.date(2024, 1, 2),
-            datetime.date(2024, 1, 3),
+            datetime.date(2025, 1, 1),
+            datetime.date(2025, 1, 2),
+            datetime.date(2025, 1, 3),
         ]
 
         prev, next_date = _find_nearest_dates(target, available)
 
         # Should find the target itself as previous, and the next one
-        self.assertEqual(prev, datetime.date(2024, 1, 2))
-        self.assertEqual(next_date, datetime.date(2024, 1, 3))
+        self.assertEqual(prev, datetime.date(2025, 1, 2))
+        self.assertEqual(next_date, datetime.date(2025, 1, 3))
 
 
 class TestAverageTVL(unittest.TestCase):
@@ -327,18 +260,9 @@ class TestAverageTVL(unittest.TestCase):
 
     def test_average_calculation(self):
         """Test that average is calculated correctly"""
-        base_date = datetime.date(2024, 1, 1)
+        base_date = datetime.date(2025, 1, 1)
         tvl_data = [
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date + datetime.timedelta(days=i),
-                        datetime.time.min,
-                        tzinfo=datetime.timezone.utc,
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1000000.0 + (i * 100000),
-            }
+            make_tvl_entry(base_date + datetime.timedelta(days=i), 1000000.0 + (i * 100000))
             for i in range(3)
         ]
 
@@ -347,7 +271,7 @@ class TestAverageTVL(unittest.TestCase):
         mock_response.json.return_value = {"tvl": tvl_data}
         self.mock_get.return_value = mock_response
 
-        avg = get_average_tvl("test-protocol", "2024-01-01", "2024-01-03")
+        avg = get_average_tvl("test-protocol", "2025-01-01", "2025-01-03")
 
         # Average of 1M, 1.1M, 1.2M = 1.1M
         self.assertAlmostEqual(avg, 1100000.0, places=2)
@@ -355,26 +279,10 @@ class TestAverageTVL(unittest.TestCase):
     def test_average_with_interpolation(self):
         """Test that average includes interpolated values"""
         # Data on Jan 1 and Jan 3, missing Jan 2
-        base_date = datetime.date(2024, 1, 1)
+        base_date = datetime.date(2025, 1, 1)
         tvl_data = [
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date, datetime.time.min, tzinfo=datetime.timezone.utc
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1000000.0,
-            },
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date + datetime.timedelta(days=2),
-                        datetime.time.min,
-                        tzinfo=datetime.timezone.utc,
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1200000.0,
-            },
+            make_tvl_entry(base_date, 1000000.0),
+            make_tvl_entry(base_date + datetime.timedelta(days=2), 1200000.0),
         ]
 
         mock_response = mock.MagicMock()
@@ -382,7 +290,7 @@ class TestAverageTVL(unittest.TestCase):
         mock_response.json.return_value = {"tvl": tvl_data}
         self.mock_get.return_value = mock_response
 
-        avg = get_average_tvl("test-protocol", "2024-01-01", "2024-01-03")
+        avg = get_average_tvl("test-protocol", "2025-01-01", "2025-01-03")
 
         # Average of 1M, 1.1M (interpolated), 1.2M = 1.1M
         self.assertAlmostEqual(avg, 1100000.0, places=2)
@@ -396,18 +304,9 @@ class TestCLIOutput(unittest.TestCase):
         self.mock_get = self.mock_response_patcher.start()
 
         # Set up mock data
-        base_date = datetime.date(2024, 1, 1)
+        base_date = datetime.date(2025, 1, 1)
         tvl_data = [
-            {
-                "date": int(
-                    datetime.datetime.combine(
-                        base_date + datetime.timedelta(days=i),
-                        datetime.time.min,
-                        tzinfo=datetime.timezone.utc,
-                    ).timestamp()
-                ),
-                "totalLiquidityUSD": 1000000.0 + (i * 100000),
-            }
+            make_tvl_entry(base_date + datetime.timedelta(days=i), 1000000.0 + (i * 100000))
             for i in range(3)
         ]
 
@@ -421,7 +320,7 @@ class TestCLIOutput(unittest.TestCase):
 
     def test_dataset_format_for_csv(self):
         """Test that dataset format is suitable for CSV output"""
-        dataset = get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-03")
+        dataset = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03")
 
         # Verify structure suitable for CSV
         self.assertIsInstance(dataset, list)
@@ -439,7 +338,7 @@ class TestCLIOutput(unittest.TestCase):
 
     def test_dataset_format_for_json(self):
         """Test that dataset format is suitable for JSON output"""
-        dataset = get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-03")
+        dataset = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03")
 
         # Verify JSON serializable
         json_str = json.dumps(dataset)
@@ -451,6 +350,243 @@ class TestCLIOutput(unittest.TestCase):
         self.assertIn("date", data[0])
         self.assertIn("tvl", data[0])
         self.assertIn("is_interpolated", data[0])
+
+
+class TestExtrapolationSlope(unittest.TestCase):
+    """Test the _get_extrapolation_slope helper function"""
+
+    def test_positive_slope(self):
+        """Test slope calculation with increasing TVL"""
+        date1 = datetime.date(2025, 1, 1)
+        date2 = datetime.date(2025, 1, 3)
+        tvl1 = 1000000.0
+        tvl2 = 1200000.0
+        
+        slope = _get_extrapolation_slope(date1, tvl1, date2, tvl2)
+        
+        # Change of 200000 over 2 days = 100000 per day
+        self.assertAlmostEqual(slope, 100000.0, places=2)
+
+    def test_negative_slope(self):
+        """Test slope calculation with decreasing TVL"""
+        date1 = datetime.date(2025, 1, 1)
+        date2 = datetime.date(2025, 1, 5)
+        tvl1 = 2000000.0
+        tvl2 = 1600000.0
+        
+        slope = _get_extrapolation_slope(date1, tvl1, date2, tvl2)
+        
+        # Change of -400000 over 4 days = -100000 per day
+        self.assertAlmostEqual(slope, -100000.0, places=2)
+
+    def test_zero_slope(self):
+        """Test slope calculation with constant TVL"""
+        date1 = datetime.date(2025, 1, 1)
+        date2 = datetime.date(2025, 1, 10)
+        tvl1 = 1000000.0
+        tvl2 = 1000000.0
+        
+        slope = _get_extrapolation_slope(date1, tvl1, date2, tvl2)
+        
+        self.assertAlmostEqual(slope, 0.0, places=2)
+
+    def test_same_date(self):
+        """Test slope calculation when dates are the same (edge case)"""
+        date1 = datetime.date(2025, 1, 1)
+        date2 = datetime.date(2025, 1, 1)
+        tvl1 = 1000000.0
+        tvl2 = 1200000.0
+        
+        slope = _get_extrapolation_slope(date1, tvl1, date2, tvl2)
+        
+        # Should return 0 to avoid division by zero
+        self.assertAlmostEqual(slope, 0.0, places=2)
+
+
+class TestExtrapolation(unittest.TestCase):
+    """Test linear extrapolation at start/end of date range"""
+
+    def setUp(self):
+        self.mock_response_patcher = mock.patch("avg_tvls.requests.get")
+        self.mock_get = self.mock_response_patcher.start()
+
+    def tearDown(self):
+        self.mock_response_patcher.stop()
+
+    def _create_mock_response(self, tvl_data):
+        """Helper to create a mock API response"""
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"tvl": tvl_data}
+        return mock_response
+
+    def test_backward_extrapolation_at_start(self):
+        """Test backward extrapolation when data exists after range start"""
+        # Data on Jan 3 and Jan 5, need to extrapolate back to Jan 1-2
+        base_date = datetime.date(2025, 1, 3)
+        tvl_data = [
+            make_tvl_entry(base_date, 1100000.0),  # Jan 3
+            make_tvl_entry(base_date + datetime.timedelta(days=2), 1300000.0),  # Jan 5
+        ]
+
+        self.mock_get.return_value = self._create_mock_response(tvl_data)
+
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=True)
+
+        self.assertEqual(len(result), 5)
+        
+        # Slope between Jan 3 (1.1M) and Jan 5 (1.3M) = 100k per day
+        # Jan 1: 1.1M - (2 days * 100k) = 900k
+        self.assertTrue(result[0]["is_interpolated"])
+        self.assertAlmostEqual(result[0]["tvl"], 900000.0, places=2)
+        
+        # Jan 2: 1.1M - (1 day * 100k) = 1M
+        self.assertTrue(result[1]["is_interpolated"])
+        self.assertAlmostEqual(result[1]["tvl"], 1000000.0, places=2)
+        
+        # Jan 3: raw data
+        self.assertFalse(result[2]["is_interpolated"])
+        self.assertEqual(result[2]["tvl"], 1100000.0)
+        
+        # Jan 4: interpolated between Jan 3 and Jan 5
+        self.assertTrue(result[3]["is_interpolated"])
+        self.assertAlmostEqual(result[3]["tvl"], 1200000.0, places=2)
+        
+        # Jan 5: raw data
+        self.assertFalse(result[4]["is_interpolated"])
+        self.assertEqual(result[4]["tvl"], 1300000.0)
+
+    def test_forward_extrapolation_at_end(self):
+        """Test forward extrapolation when data exists before range end"""
+        # Data on Jan 1 and Jan 3, need to extrapolate forward to Jan 4-5
+        base_date = datetime.date(2025, 1, 1)
+        tvl_data = [
+            make_tvl_entry(base_date, 1000000.0),  # Jan 1
+            make_tvl_entry(base_date + datetime.timedelta(days=2), 1200000.0),  # Jan 3
+        ]
+
+        self.mock_get.return_value = self._create_mock_response(tvl_data)
+
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=True)
+
+        self.assertEqual(len(result), 5)
+        
+        # Jan 1: raw data
+        self.assertFalse(result[0]["is_interpolated"])
+        self.assertEqual(result[0]["tvl"], 1000000.0)
+        
+        # Jan 2: interpolated between Jan 1 and Jan 3
+        self.assertTrue(result[1]["is_interpolated"])
+        self.assertAlmostEqual(result[1]["tvl"], 1100000.0, places=2)
+        
+        # Jan 3: raw data
+        self.assertFalse(result[2]["is_interpolated"])
+        self.assertEqual(result[2]["tvl"], 1200000.0)
+        
+        # Slope between Jan 1 (1M) and Jan 3 (1.2M) = 100k per day
+        # Jan 4: 1.2M + (1 day * 100k) = 1.3M
+        self.assertTrue(result[3]["is_interpolated"])
+        self.assertAlmostEqual(result[3]["tvl"], 1300000.0, places=2)
+        
+        # Jan 5: 1.2M + (2 days * 100k) = 1.4M
+        self.assertTrue(result[4]["is_interpolated"])
+        self.assertAlmostEqual(result[4]["tvl"], 1400000.0, places=2)
+
+    def test_no_extrapolate_skips_start_dates(self):
+        """Test that no_extrapolate=True skips dates at the start"""
+        # Data on Jan 3 and Jan 5, range from Jan 1-5
+        base_date = datetime.date(2025, 1, 3)
+        tvl_data = [
+            make_tvl_entry(base_date, 1100000.0),  # Jan 3
+            make_tvl_entry(base_date + datetime.timedelta(days=2), 1300000.0),  # Jan 5
+        ]
+
+        self.mock_get.return_value = self._create_mock_response(tvl_data)
+
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=False)
+
+        # Should only have Jan 3, 4, 5 (Jan 1-2 are skipped)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0]["date"], "2025-01-03")
+        self.assertEqual(result[1]["date"], "2025-01-04")
+        self.assertEqual(result[2]["date"], "2025-01-05")
+
+    def test_no_extrapolate_skips_end_dates(self):
+        """Test that no_extrapolate=True skips dates at the end"""
+        # Data on Jan 1 and Jan 3, range from Jan 1-5
+        base_date = datetime.date(2025, 1, 1)
+        tvl_data = [
+            make_tvl_entry(base_date, 1000000.0),  # Jan 1
+            make_tvl_entry(base_date + datetime.timedelta(days=2), 1200000.0),  # Jan 3
+        ]
+
+        self.mock_get.return_value = self._create_mock_response(tvl_data)
+
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=False)
+
+        # Should only have Jan 1, 2, 3 (Jan 4-5 are skipped)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0]["date"], "2025-01-01")
+        self.assertEqual(result[1]["date"], "2025-01-02")
+        self.assertEqual(result[2]["date"], "2025-01-03")
+
+    def test_extrapolation_with_negative_slope(self):
+        """Test extrapolation with decreasing TVL"""
+        # Data on Jan 1 and Jan 3 with decreasing TVL, extrapolate to Jan 4-5
+        base_date = datetime.date(2025, 1, 1)
+        tvl_data = [
+            make_tvl_entry(base_date, 1200000.0),  # Jan 1
+            make_tvl_entry(base_date + datetime.timedelta(days=2), 1000000.0),  # Jan 3
+        ]
+
+        self.mock_get.return_value = self._create_mock_response(tvl_data)
+
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=True)
+
+        self.assertEqual(len(result), 5)
+        
+        # Slope between Jan 1 (1.2M) and Jan 3 (1M) = -100k per day
+        # Jan 4: 1M + (1 day * -100k) = 900k
+        self.assertTrue(result[3]["is_interpolated"])
+        self.assertAlmostEqual(result[3]["tvl"], 900000.0, places=2)
+        
+        # Jan 5: 1M + (2 days * -100k) = 800k
+        self.assertTrue(result[4]["is_interpolated"])
+        self.assertAlmostEqual(result[4]["tvl"], 800000.0, places=2)
+
+    def test_average_tvl_with_extrapolation(self):
+        """Test that get_average_tvl respects extrapolate parameter"""
+        # Data on Jan 3 and Jan 5, range from Jan 1-5
+        # This creates a situation where extrapolation is needed at the start
+        base_date = datetime.date(2025, 1, 3)
+        tvl_data = [
+            make_tvl_entry(base_date, 1100000.0),  # Jan 3
+            make_tvl_entry(base_date + datetime.timedelta(days=2), 1300000.0),  # Jan 5
+        ]
+
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"tvl": tvl_data}
+        self.mock_get.return_value = mock_response
+
+        # With extrapolation (should have 5 days: Jan 1-5)
+        # Slope = 100k/day, so Jan 1 = 900k, Jan 2 = 1M, Jan 3 = 1.1M, Jan 4 = 1.2M, Jan 5 = 1.3M
+        # Average = (900k + 1M + 1.1M + 1.2M + 1.3M) / 5 = 5.5M / 5 = 1.1M
+        avg_with = get_average_tvl("test-protocol", "2025-01-01", "2025-01-05", extrapolate=True)
+        
+        # Without extrapolation (should have 3 days: Jan 3, 4, 5)
+        # Jan 3 = 1.1M (raw), Jan 4 = 1.2M (interpolated), Jan 5 = 1.3M (raw)
+        # Average = (1.1M + 1.2M + 1.3M) / 3 = 3.6M / 3 = 1.2M
+        avg_without = get_average_tvl("test-protocol", "2025-01-01", "2025-01-05", extrapolate=False)
+        
+        # Averages should be different
+        self.assertNotEqual(avg_with, avg_without)
+        
+        # With extrapolation average should be 1.1M
+        self.assertAlmostEqual(avg_with, 1100000.0, places=2)
+        
+        # Without extrapolation should be 1.2M
+        self.assertAlmostEqual(avg_without, 1200000.0, places=2)
 
 
 if __name__ == "__main__":

--- a/test_avg_tvls.py
+++ b/test_avg_tvls.py
@@ -48,7 +48,7 @@ class TestTVLDataset(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03", by_chain=False)
 
         self.assertEqual(len(result), 3)
         # All rows should have raw data (tvl_raw is not None)
@@ -72,7 +72,7 @@ class TestTVLDataset(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03", by_chain=False)
 
         self.assertEqual(len(result), 3)
         # Jan 1: raw data
@@ -93,7 +93,7 @@ class TestTVLDataset(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-02")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-02", by_chain=False)
 
         self.assertEqual(len(result), 2)
         # Jan 1: no extrapolation by default, both fields are None
@@ -112,7 +112,7 @@ class TestTVLDataset(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-02", extrapolate=True)
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-02", extrapolate=True, by_chain=False)
 
         self.assertEqual(len(result), 2)
         # Jan 1: forward-fill from Jan 2 (fallback with only 1 data point)
@@ -130,7 +130,7 @@ class TestTVLDataset(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-02")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-02", by_chain=False)
 
         self.assertEqual(len(result), 2)
         # Jan 1: raw data
@@ -149,7 +149,7 @@ class TestTVLDataset(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-02", extrapolate=True)
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-02", extrapolate=True, by_chain=False)
 
         self.assertEqual(len(result), 2)
         # Jan 1: raw data
@@ -171,7 +171,7 @@ class TestTVLDataset(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-06")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-06", by_chain=False)
 
         self.assertEqual(len(result), 6)
         # Jan 1: raw
@@ -199,7 +199,7 @@ class TestTVLDataset(unittest.TestCase):
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
         with self.assertRaises(ValueError) as context:
-            get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-31")
+            get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-31", by_chain=False)
 
         self.assertIn("No TVL data available", str(context.exception))
 
@@ -210,7 +210,7 @@ class TestTVLDataset(unittest.TestCase):
         self.mock_get.return_value = mock_response
 
         with self.assertRaises(ValueError) as context:
-            get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-31")
+            get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-31", by_chain=False)
 
         self.assertIn("Error fetching data", str(context.exception))
 
@@ -222,7 +222,7 @@ class TestTVLDataset(unittest.TestCase):
         self.mock_get.return_value = mock_response
 
         with self.assertRaises(ValueError) as context:
-            get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-31")
+            get_tvl_dataset("test-protocol", "2024-01-01", "2024-01-31", by_chain=False)
 
         self.assertIn("No TVL data found", str(context.exception))
 
@@ -361,7 +361,7 @@ class TestCLIOutput(unittest.TestCase):
 
     def test_dataset_format_for_csv(self):
         """Test that dataset format is suitable for CSV output"""
-        dataset = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03")
+        dataset = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03", by_chain=False)
 
         # Verify structure suitable for CSV
         self.assertIsInstance(dataset, list)
@@ -378,7 +378,7 @@ class TestCLIOutput(unittest.TestCase):
 
     def test_dataset_format_for_json(self):
         """Test that dataset format is suitable for JSON output"""
-        dataset = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03")
+        dataset = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03", by_chain=False)
 
         # Verify JSON serializable
         json_str = json.dumps(dataset)
@@ -417,7 +417,7 @@ class TestDefaultExtrapolationBehavior(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", by_chain=False)
 
         # All 5 dates should be included
         self.assertEqual(len(result), 5)
@@ -432,7 +432,7 @@ class TestDefaultExtrapolationBehavior(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", by_chain=False)
 
         # Jan 1, 2 (before data) should have None for both fields
         self.assertIsNone(result[0]["tvl_raw"])
@@ -489,7 +489,7 @@ class TestSeparateRawAndInterpolatedFields(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03", by_chain=False)
 
         # Jan 1: has raw data
         self.assertEqual(result[0]["tvl_raw"], 1000000.0)
@@ -508,7 +508,7 @@ class TestSeparateRawAndInterpolatedFields(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03", by_chain=False)
 
         for row in result:
             self.assertEqual(row["tvl_raw"], row["tvl_interpolated"])
@@ -524,7 +524,7 @@ class TestSeparateRawAndInterpolatedFields(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03")
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03", by_chain=False)
 
         # Jan 2: no raw data but has interpolated value
         self.assertIsNone(result[1]["tvl_raw"])
@@ -539,7 +539,7 @@ class TestSeparateRawAndInterpolatedFields(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03", extrapolate=False)
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03", extrapolate=False, by_chain=False)
 
         # Jan 1: no raw and cannot interpolate (no previous data)
         self.assertIsNone(result[0]["tvl_raw"])
@@ -631,7 +631,7 @@ class TestExtrapolation(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=True)
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=True, by_chain=False)
 
         self.assertEqual(len(result), 5)
         
@@ -667,7 +667,7 @@ class TestExtrapolation(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=True)
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=True, by_chain=False)
 
         self.assertEqual(len(result), 5)
         
@@ -703,7 +703,7 @@ class TestExtrapolation(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=False)
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=False, by_chain=False)
 
         # Should have all 5 dates, Jan 1-2 with None TVL
         self.assertEqual(len(result), 5)
@@ -729,7 +729,7 @@ class TestExtrapolation(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=False)
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=False, by_chain=False)
 
         # Should have all 5 dates, Jan 4-5 with None TVL
         self.assertEqual(len(result), 5)
@@ -755,7 +755,7 @@ class TestExtrapolation(unittest.TestCase):
 
         self.mock_get.return_value = self._create_mock_response(tvl_data)
 
-        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=True)
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-05", extrapolate=True, by_chain=False)
 
         self.assertEqual(len(result), 5)
         
@@ -801,6 +801,197 @@ class TestExtrapolation(unittest.TestCase):
         
         # Without extrapolation should be 1.2M (None values are filtered out)
         self.assertAlmostEqual(avg_without, 1200000.0, places=2)
+
+
+class TestChainBreakdown(unittest.TestCase):
+    """Test the by_chain=True functionality"""
+
+    def setUp(self):
+        self.mock_response_patcher = mock.patch("avg_tvls.requests.get")
+        self.mock_get = self.mock_response_patcher.start()
+
+    def tearDown(self):
+        self.mock_response_patcher.stop()
+
+    def _create_mock_response_with_chains(self, chain_data: dict):
+        """Helper to create a mock API response with chainTvls"""
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "tvl": [],  # Empty aggregate, chains only
+            "chainTvls": chain_data,
+        }
+        return mock_response
+
+    def test_by_chain_returns_chain_columns(self):
+        """Test that by_chain=True returns separate columns for each chain"""
+        base_date = datetime.date(2025, 1, 1)
+        chain_data = {
+            "Ethereum": {
+                "tvl": [
+                    make_tvl_entry(base_date, 1000000.0),
+                    make_tvl_entry(base_date + datetime.timedelta(days=1), 1100000.0),
+                ]
+            },
+            "Arbitrum": {
+                "tvl": [
+                    make_tvl_entry(base_date, 500000.0),
+                    make_tvl_entry(base_date + datetime.timedelta(days=1), 550000.0),
+                ]
+            },
+        }
+
+        self.mock_get.return_value = self._create_mock_response_with_chains(chain_data)
+
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-02", by_chain=True)
+
+        self.assertEqual(len(result), 2)
+        # Check for chain columns
+        self.assertIn("Ethereum_raw", result[0])
+        self.assertIn("Ethereum_interpolated", result[0])
+        self.assertIn("Arbitrum_raw", result[0])
+        self.assertIn("Arbitrum_interpolated", result[0])
+        self.assertIn("total_raw", result[0])
+        self.assertIn("total_interpolated", result[0])
+
+    def test_chain_totals_sum_correctly(self):
+        """Test that total columns are sum of individual chain values"""
+        base_date = datetime.date(2025, 1, 1)
+        chain_data = {
+            "Ethereum": {
+                "tvl": [make_tvl_entry(base_date, 1000000.0)]
+            },
+            "Arbitrum": {
+                "tvl": [make_tvl_entry(base_date, 500000.0)]
+            },
+        }
+
+        self.mock_get.return_value = self._create_mock_response_with_chains(chain_data)
+
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-01", by_chain=True)
+
+        # Total should be sum of chains
+        self.assertEqual(result[0]["total_raw"], 1500000.0)
+        self.assertEqual(result[0]["total_interpolated"], 1500000.0)
+
+    def test_chain_interpolation_independent(self):
+        """Test that each chain is interpolated independently"""
+        base_date = datetime.date(2025, 1, 1)
+        chain_data = {
+            "Ethereum": {
+                "tvl": [
+                    make_tvl_entry(base_date, 1000000.0),
+                    make_tvl_entry(base_date + datetime.timedelta(days=2), 1200000.0),
+                ]
+            },
+            "Arbitrum": {
+                "tvl": [
+                    # Missing Jan 1, has Jan 2 only
+                    make_tvl_entry(base_date + datetime.timedelta(days=1), 500000.0),
+                ]
+            },
+        }
+
+        self.mock_get.return_value = self._create_mock_response_with_chains(chain_data)
+
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03", by_chain=True)
+
+        self.assertEqual(len(result), 3)
+        
+        # Jan 1: Ethereum has raw, Arbitrum has None (can't interpolate)
+        self.assertEqual(result[0]["Ethereum_raw"], 1000000.0)
+        self.assertIsNone(result[0]["Arbitrum_raw"])
+        self.assertIsNone(result[0]["Arbitrum_interpolated"])
+        
+        # Jan 2: Ethereum interpolated (1.1M), Arbitrum has raw
+        self.assertIsNone(result[1]["Ethereum_raw"])
+        self.assertAlmostEqual(result[1]["Ethereum_interpolated"], 1100000.0, places=2)
+        self.assertEqual(result[1]["Arbitrum_raw"], 500000.0)
+        
+        # Jan 3: Ethereum has raw (1.2M), Arbitrum has None
+        self.assertEqual(result[2]["Ethereum_raw"], 1200000.0)
+        self.assertIsNone(result[2]["Arbitrum_raw"])
+
+    def test_by_chain_excludes_borrowed_variants(self):
+        """Test that borrowed/staking/pool2 variants are excluded"""
+        base_date = datetime.date(2025, 1, 1)
+        chain_data = {
+            "Ethereum": {
+                "tvl": [make_tvl_entry(base_date, 1000000.0)]
+            },
+            "Ethereum-borrowed": {
+                "tvl": [make_tvl_entry(base_date, 800000.0)]
+            },
+            "borrowed": {
+                "tvl": [make_tvl_entry(base_date, 800000.0)]
+            },
+            "staking": {
+                "tvl": [make_tvl_entry(base_date, 200000.0)]
+            },
+        }
+
+        self.mock_get.return_value = self._create_mock_response_with_chains(chain_data)
+
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-01", by_chain=True)
+
+        # Should only have Ethereum, not borrowed variants
+        self.assertIn("Ethereum_raw", result[0])
+        self.assertNotIn("Ethereum-borrowed_raw", result[0])
+        self.assertNotIn("borrowed_raw", result[0])
+        self.assertNotIn("staking_raw", result[0])
+        
+        # Total should only include Ethereum
+        self.assertEqual(result[0]["total_raw"], 1000000.0)
+
+    def test_by_chain_false_returns_aggregate(self):
+        """Test backward compatibility: by_chain=False returns aggregate data"""
+        base_date = datetime.date(2025, 1, 1)
+        
+        # Create response with both aggregate tvl and chainTvls
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "tvl": [make_tvl_entry(base_date, 1500000.0)],
+            "chainTvls": {
+                "Ethereum": {"tvl": [make_tvl_entry(base_date, 1000000.0)]},
+                "Arbitrum": {"tvl": [make_tvl_entry(base_date, 500000.0)]},
+            },
+        }
+        self.mock_get.return_value = mock_response
+
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-01", by_chain=False)
+
+        # Should return aggregate format, not chain format
+        self.assertIn("tvl_raw", result[0])
+        self.assertIn("tvl_interpolated", result[0])
+        self.assertNotIn("Ethereum_raw", result[0])
+        self.assertEqual(result[0]["tvl_raw"], 1500000.0)
+
+    def test_chain_data_with_extrapolation(self):
+        """Test that extrapolation works with chain data"""
+        base_date = datetime.date(2025, 1, 2)
+        chain_data = {
+            "Ethereum": {
+                "tvl": [
+                    make_tvl_entry(base_date, 1000000.0),
+                    make_tvl_entry(base_date + datetime.timedelta(days=1), 1100000.0),
+                ]
+            },
+        }
+
+        self.mock_get.return_value = self._create_mock_response_with_chains(chain_data)
+
+        # Request range starting before data
+        result = get_tvl_dataset("test-protocol", "2025-01-01", "2025-01-03", by_chain=True, extrapolate=True)
+
+        self.assertEqual(len(result), 3)
+        
+        # Jan 1: extrapolated backward
+        self.assertIsNone(result[0]["Ethereum_raw"])
+        self.assertIsNotNone(result[0]["Ethereum_interpolated"])
+        
+        # Jan 2: raw data
+        self.assertEqual(result[1]["Ethereum_raw"], 1000000.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

This PR extends the TVL tooling to support **per-chain TVL breakdowns** (with totals) and refactors the data model & CLI flags to make interpolation/extrapolation behavior explicit and more flexible.

---

### API & Data Model

* Extend `get_tvl_dataset(protocol, start_date, end_date, extrapolate=False, by_chain=True)`:

  * `by_chain=False` → aggregate-only rows:

    * `date`, `tvl_raw`, `tvl_interpolated`
  * `by_chain=True` (default) → per-chain rows:

    * `date`
    * `{chain}_raw`, `{chain}_interpolated` for each chain
    * `total_raw`, `total_interpolated` as sums across chains

* Parse `chainTvls` from the DeFiLlama response; **exclude** `borrowed`, `staking`, `pool2` variants (e.g. `Ethereum-borrowed`, `staking`, `-pool2`).

* Replace `{date, tvl, is_interpolated}` with `{date, tvl_raw, tvl_interpolated}`:

  * `tvl_raw`: raw point or `None` if the date has no direct data.
  * `tvl_interpolated`: equals `tvl_raw` when raw exists, otherwise interpolated/extrapolated, or `None` if no reliable value.

* Add helpers:

  * `_get_extrapolation_slope()` to compute TVL/day between two points.
  * `_process_tvl_series()` to centralize raw/interpolated/extrapolated/None logic.
  * `_get_tvl_dataset_by_chain()` to build the per-chain dataset.
  * `_output_chain_csv()` for CSV with dynamic per-chain columns.

* `get_average_tvl(protocol, start_date, end_date, extrapolate=False)`:

  * Uses `get_tvl_dataset(..., by_chain=False)` internally.
  * Averages over `tvl_interpolated` only, ignoring `None`.

---

### Interpolation / Extrapolation Semantics

* Default: `extrapolate=False`.
* All dates in `[start_date, end_date]` are always included.
* When extrapolation is disabled and interpolation is impossible (only one-sided data), both `tvl_raw` and `tvl_interpolated` are `None`.
* When `extrapolate=True`, edge dates are filled using linear extrapolation based on nearest two points on each side, per series.

---

### CLI & UX

* Add `--extrapolate` flag (opt-in):

  * Default behavior is now **no extrapolation**; use `--extrapolate` to enable edge extrapolation.
* Add `--no-by-chain` flag:

  * Default: per-chain CSV with `_output_chain_csv()`:

    * `date,<chain1>_raw,<chain1>_interpolated,...,total_raw,total_interpolated`
  * `--no-by-chain`: aggregate CSV:

    * `date,tvl_raw,tvl_interpolated`
* `--mean` mode preserved for backward compatibility; uses `tvl_interpolated` and respects `--extrapolate`.

---

### Makefile & Docs

* `Makefile`:

  * Add `tvl` and `avgtvl` targets with examples, including `OPTS='--extrapolate'`, `OPTS='--mean'`, and `OPTS='--no-by-chain'`.
* `README.md`:

  * Document:

    * TVL behavior (interpolation + optional extrapolation).
    * New CLI flags (`--extrapolate`, `--no-by-chain`).
    * `make tvl` / `make avgtvl` usage and example outputs.
